### PR TITLE
Handle case where destroyed element is only child

### DIFF
--- a/addon/mixins/transition-mixin.js
+++ b/addon/mixins/transition-mixin.js
@@ -142,7 +142,6 @@ export default Mixin.create({
       var idx = parent.children().index(this.$());
       run.scheduleOnce('afterRender', () => {
         this.addDestroyedElementClone(parent, idx, clone);
-        Ember.$(parent.children()[idx - 1]).after(clone);
         this.transitionDomNode(clone[0], this.get('transitionClass'), 'leave', () => {
           this.didTransitionOut(clone);
         });
@@ -152,11 +151,13 @@ export default Mixin.create({
 
   /**
    * Default placement  of the cloned element when being destroyed.
-   * This might be overridden if component is wrapped in another component.
-   * Forexample if you are using ember-wormhole you should use parent.append(clone) instead of the default implementation.
    */
   addDestroyedElementClone(parent, idx, clone) {
+    if (parent.children().length === 0) {
+      parent.append(clone);
+    } else {
       Ember.$(parent.children()[idx - 1]).after(clone);
+    }
   },
 
   /**

--- a/addon/mixins/transition-mixin.js
+++ b/addon/mixins/transition-mixin.js
@@ -153,8 +153,8 @@ export default Mixin.create({
    * Default placement  of the cloned element when being destroyed.
    */
   addDestroyedElementClone(parent, idx, clone) {
-    if (parent.children().length === 0) {
-      parent.append(clone);
+    if (idx === 0) {
+      parent.prepend(clone);
     } else {
       Ember.$(parent.children()[idx - 1]).after(clone);
     }


### PR DESCRIPTION
This makes `TransitionMixin.addDestroyedElementClone()` smart enough to deal with the situation where the element that was removed is the only child.  There was a comment stating that this could be a possibility and should be handled by overriding it.  However, it seems to me like this scenario can occur frequently enough that it would confuse new users of the addon (it confused me for a bit).   