### PR TITLE
[RUN]: loop around addObject and removeObject for acceptance tests

### DIFF
--- a/addon/mixins/transition-mixin.js
+++ b/addon/mixins/transition-mixin.js
@@ -28,7 +28,9 @@ export default Mixin.create({
 
   addClass(className, $element) {
     if (!this.get('isDestroying')) {
-      this.get('transitionClasses').addObject(className);
+      run(() => {
+        this.get('transitionClasses').addObject(className);
+      });
     } else {
       $element.addClass(className);
     }
@@ -36,7 +38,9 @@ export default Mixin.create({
 
   removeClass(className, $element) {
     if (!this.get('isDestroying')) {
-      this.get('transitionClasses').removeObject(className);
+      run(() => {
+        this.get('transitionClasses').removeObject(className);
+      });
     } else {
       $element.removeClass(className);
     }


### PR DESCRIPTION
Acceptance tests are having run loop issues w/o wrapping addObject and removeObject with a run.  Have a local acceptance test, but can't get it to fail by clicking a button, only shows run loop issue if pauseTest() in middle of test and click button.  

Lmk if you want an acceptance test with this pull request!