### PR TITLE
Support css animation classes mimic reactjs/react-transition-group v1

### DIFF
--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,24 +1,46 @@
 /* BEGIN-SNIPPET insert-destroy.css */
 .example-enter {
   opacity: 0;
-  height: 0px;
+  max-height: 0px;
 }
 
 .example-enter.example-enter-active {
   opacity: 1;
-  height: 50px;
+  max-height: 50px;
   transition: all 0.5s ease-in;
 }
 
 .example-leave {
   opacity: 1;
-  height: 50px;
+  max-height: 50px;
 }
 
 .example-leave.example-leave-active {
   opacity: 0;
-  height: 0;
+  max-height: 0;
   transition: all 0.5s ease-in;
+}
+/* END-SNIPPET */
+
+/* BEGIN-SNIPPET insert-destroy-verbose.css */
+.duration-500 {
+  transition-duration: 500ms;
+}
+
+.opacity-0 {
+  opacity: 0;
+}
+
+.opacity-100 {
+  opacity: 100;
+}
+
+.max-h-0	{
+  max-height: 0;
+}
+
+.max-h-12	{
+  max-height: 3rem;
 }
 /* END-SNIPPET */
 

--- a/tests/dummy/app/templates/docs/insert-destroy.md
+++ b/tests/dummy/app/templates/docs/insert-destroy.md
@@ -27,4 +27,29 @@ Let's look at one example:
   Notice how the positional argument is used for the prefix of the css classes you define.
 </aside>
 
+## **Manually specifying class names**
+
+Each individual class can also be specified independently like below.
+
+*This does not work with Animate/ Tailwind enter/ enterActive and leave/ leaveActive are applied at the same time. Whichever one is last in the stylesheet wins*
+
+*Here, using Tailwind inspired classes, fading in works but fading out does not. 😢*
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name="insert-destroy-verbose.hbs"}}
+    <button class="docs-btn" {{on "click" (action (mut this.show2) (not show2))}}>
+      Press me
+    </button>
+
+    {{#if this.show2}}
+      <div {{css-transition (hash enter="opacity-0 max-h-0" enterActive="duration-500 opacity-100 max-h-12" leave="opacity-100 max-h-12" leaveActive="opacity-0 duration-500 max-h-0")}}>
+        <h1>Hello world</h1>
+      </div>
+    {{/if}}
+  {{/demo.example}}
+
+  {{demo.snippet "insert-destroy-verbose.hbs"}}
+  {{demo.snippet "insert-destroy-verbose.css"}}
+{{/docs-demo}}
+
 You're free to customize your element like you normally would. The modifier will only apply and remove the classes and nothing else.


### PR DESCRIPTION
Addresses #35

This is what ember-css-transitions links to as the main inspiration for this add-on. The version they are referring to in the React docs is actually v1.

This branch attempts to support passing in a hash of class names as mentioned here: https://github.com/peec/ember-css-transitions/issues/35#issuecomment-614995716

*Unfortunately this won’t work for Tailwind, Animate.css users. Due to both enter/ enterActive (or leave/leaveActive) classes being applied the latest class in the stylesheet will show. So in my PR fade-in works but fade-out does not.*