### PR TITLE
Support css animation classes mimic reactjs/react-transition-group v4

### DIFF
--- a/addon/modifiers/css-transition.js
+++ b/addon/modifiers/css-transition.js
@@ -234,8 +234,9 @@ export default class CssTransitionModifier extends Modifier {
     // which is necessary in order to transition styles when adding a class name.
     element.scrollTop;
 
-    // add active class after repaint
+    // add activeClass & remove class after repaint
     this.addClass(activeClassName);
+    this.removeClass(className);
 
     // wait for ember to apply classes
     // set timeout for animation end

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -4,7 +4,7 @@
   max-height: 0px;
 }
 
-.example-enter.example-enter-active {
+.example-enter-active {
   opacity: 1;
   max-height: 50px;
   transition: all 0.5s ease-in;
@@ -15,7 +15,7 @@
   max-height: 50px;
 }
 
-.example-leave.example-leave-active {
+.example-leave-active {
   opacity: 0;
   max-height: 0;
   transition: all 0.5s ease-in;
@@ -45,18 +45,18 @@
 /* END-SNIPPET */
 
 /* BEGIN-SNIPPET class-add-removal.css*/
-.is-important-add, .is-important-remove {
+.is-important,
+.is-important-add-active,
+.is-important-remove {
+  color: red;
+  font-size: 1.5em;
   transition: all cubic-bezier(0.250, 0.460, 0.450, 0.940) 0.5s;
 }
 
-.is-important,
-.is-important-add.is-important-add-active {
-  color: red;
-  font-size: 1.5em;
-}
-
-.is-important-remove.is-important-remove-active {
+.is-important-add,
+.is-important-remove-active {
   font-size: 1.0em;
   color: black;
+  transition: all cubic-bezier(0.250, 0.460, 0.450, 0.940) 0.5s;
 }
 /* END-SNIPPET */

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,24 +1,46 @@
 /* BEGIN-SNIPPET insert-destroy.css */
 .example-enter {
   opacity: 0;
-  height: 0px;
+  max-height: 0px;
 }
 
 .example-enter.example-enter-active {
   opacity: 1;
-  height: 50px;
+  max-height: 50px;
   transition: all 0.5s ease-in;
 }
 
 .example-leave {
   opacity: 1;
-  height: 50px;
+  max-height: 50px;
 }
 
 .example-leave.example-leave-active {
   opacity: 0;
-  height: 0;
+  max-height: 0;
   transition: all 0.5s ease-in;
+}
+/* END-SNIPPET */
+
+/* BEGIN-SNIPPET insert-destroy-verbose.css */
+.duration-500 {
+  transition-duration: 500ms;
+}
+
+.opacity-0 {
+  opacity: 0;
+}
+
+.opacity-100 {
+  opacity: 100;
+}
+
+.max-h-0	{
+  max-height: 0;
+}
+
+.max-h-12	{
+  max-height: 3rem;
 }
 /* END-SNIPPET */
 

--- a/tests/dummy/app/templates/docs/insert-destroy.md
+++ b/tests/dummy/app/templates/docs/insert-destroy.md
@@ -27,4 +27,29 @@ Let's look at one example:
   Notice how the positional argument is used for the prefix of the css classes you define.
 </aside>
 
+## **Manually specifying class names**
+
+Each individual class can also be specified independently like below.
+
+*This does not work with Animate/ Tailwind enter/ enterActive and leave/ leaveActive are applied at the same time. Whichever one is last in the stylesheet wins*
+
+*Here, using Tailwind inspired classes, fading in works but fading out does not. 😢*
+
+{{#docs-demo as |demo|}}
+  {{#demo.example name="insert-destroy-verbose.hbs"}}
+    <button class="docs-btn" {{on "click" (action (mut this.show2) (not show2))}}>
+      Press me
+    </button>
+
+    {{#if this.show2}}
+      <div {{css-transition (hash enter="opacity-0 max-h-0" enterActive="duration-500 opacity-100 max-h-12" leave="opacity-100 max-h-12" leaveActive="opacity-0 duration-500 max-h-0")}}>
+        <h1>Hello world</h1>
+      </div>
+    {{/if}}
+  {{/demo.example}}
+
+  {{demo.snippet "insert-destroy-verbose.hbs"}}
+  {{demo.snippet "insert-destroy-verbose.css"}}
+{{/docs-demo}}
+
 You're free to customize your element like you normally would. The modifier will only apply and remove the classes and nothing else.

--- a/tests/dummy/app/templates/docs/insert-destroy.md
+++ b/tests/dummy/app/templates/docs/insert-destroy.md
@@ -31,10 +31,6 @@ Let's look at one example:
 
 Each individual class can also be specified independently like below.
 
-*This does not work with Animate/ Tailwind enter/ enterActive and leave/ leaveActive are applied at the same time. Whichever one is last in the stylesheet wins*
-
-*Here, using Tailwind inspired classes, fading in works but fading out does not. 😢*
-
 {{#docs-demo as |demo|}}
   {{#demo.example name="insert-destroy-verbose.hbs"}}
     <button class="docs-btn" {{on "click" (action (mut this.show2) (not show2))}}>


### PR DESCRIPTION
Addresses #35

This is the same React library’s latest version. They have changed to an approach that will work but does result in a breaking change.

The breaking change is ember-css-transition users are going to have to update their css. The difference is enter is added, then removed and enterActive is added.