### PR TITLE
Avoid errors from the asynchrony in the modifier lifecycle hooks

### DIFF
--- a/addon/modifiers/css-transition.js
+++ b/addon/modifiers/css-transition.js
@@ -22,6 +22,7 @@ export default class CssTransitionModifier extends Modifier {
   clone = null;
   parentElement = null;
   nextElementSibling = null;
+  installed = false;
 
 
   get el() {
@@ -47,19 +48,31 @@ export default class CssTransitionModifier extends Modifier {
       this.addClass(className);
 
       await nextTick();
+
+      if (!this.element) {
+        return;
+      }
+
       await this.transition('enter', transitionClass);
+
+      if (!this.element) {
+        return;
+      }
 
       if (this.args.named.didTransitionIn) {
         this.args.named.didTransitionIn();
       }
     }
 
+
+
     this.parentElement = this.element.parentElement;
     this.nextElementSibling = this.element.nextElementSibling;
+    this.installed = true;
   }
 
   async willRemove() {
-    if (this.args.named.isEnabled === false) {
+    if (this.args.named.isEnabled === false || !this.installed) {
       return;
     }
 
@@ -170,7 +183,11 @@ export default class CssTransitionModifier extends Modifier {
     // add first class right away
     this.addClass(className);
 
-    await nextTick()
+    await nextTick();
+
+    if (!this.el) {
+      return;
+    }
 
     // This is for to force a repaint,
     // which is necessary in order to transition styles when adding a class name.
@@ -187,6 +204,10 @@ export default class CssTransitionModifier extends Modifier {
     // wait for ember to apply classes
     // set timeout for animation end
     await sleep(computeTimeout(element) || 0);
+
+    if (!this.el) {
+      return;
+    }
 
     this.removeClass(className);
     this.removeClass(activeClassName);

--- a/addon/modifiers/css-transition.js
+++ b/addon/modifiers/css-transition.js
@@ -150,6 +150,9 @@ export default class CssTransitionModifier extends Modifier {
     let original = this.element;
     let parentElement = original.parentElement || this.parentElement;
     let nextElementSibling = original.nextElementSibling || this.nextElementSibling;
+    if (nextElementSibling && (nextElementSibling.parentElement !== parentElement)) {
+      nextElementSibling = null;
+    }
     let clone = original.cloneNode(true);
 
     clone.setAttribute('id', `${original.id}_clone`);

--- a/tests/integration/components/css-transition-test.js
+++ b/tests/integration/components/css-transition-test.js
@@ -92,6 +92,53 @@ module('Integration | Component | transition group', function(hooks) {
       assert.ok(this.didTransitionOut.calledOnce, 'didTransitionOut was called once');
     });
 
+    test(`teardown after -enter-active is applied does not throw errors (${i.name})`, async function(assert) {
+      assert.expect(6);
+
+      this.didTransitionIn = spy();
+      this.didTransitionOut = spy();
+
+      this.set('show', false);
+
+      await render(i.template);
+
+      this.set('show', true);
+
+      assert.dom('#my-element').exists({ count: 1 }, 'element is rendered');
+      assert.dom('#my-element').hasClass('example-enter', '-enter is immediately applied');
+
+      await waitFor('#my-element.example-enter-active');
+
+      this.set('show', false);
+
+      assert.dom('#my-element').doesNotExist('element is removed');
+      assert.ok(this.didTransitionIn.notCalled, 'didTransitionIn was not called');
+      assert.ok(this.didTransitionOut.notCalled, 'didTransitionOut was not called');
+      assert.dom('#my-element_clone').doesNotExist('clone was not created');
+    });
+
+    test(`teardown after -enter is applied does not throw errors (${i.name})`, async function(assert) {
+      assert.expect(6);
+
+      this.didTransitionIn = spy();
+      this.didTransitionOut = spy();
+
+      this.set('show', false);
+
+      await render(i.template);
+
+      this.set('show', true);
+
+      assert.dom('#my-element').exists({ count: 1 }, 'element is rendered');
+      assert.dom('#my-element').hasClass('example-enter', '-enter is immediately applied');
+
+      this.set('show', false);
+
+      assert.dom('#my-element').doesNotExist('element is removed');
+      assert.ok(this.didTransitionIn.notCalled, 'didTransitionIn was not called');
+      assert.ok(this.didTransitionOut.notCalled, 'didTransitionOut was not called');
+      assert.dom('#my-element_clone').doesNotExist('clone was not created');
+    });
   });
 
   testCases = [{
@@ -171,7 +218,6 @@ module('Integration | Component | transition group', function(hooks) {
       assert.ok(this.didTransitionIn.calledOnceWith('is-important'), 'didTransitionIn was called once with is-important');
       assert.ok(this.didTransitionOut.calledOnceWith('is-important'), 'didTransitionOut was called once with is-important');
     });
-
   });
 
   test('element should have class applied when provided value is true to start with', async function(assert) {

--- a/tests/integration/components/css-transition-test.js
+++ b/tests/integration/components/css-transition-test.js
@@ -300,4 +300,44 @@ module('Integration | Component | transition group', function(hooks) {
     assert.dom('#my-element').hasClass('classes', 'element still has provided classes');
     assert.dom('#my-element').doesNotHaveClass('is-important', 'does not have transition class');
   });
+
+  test('teardown by removal of the parent element', async function(assert) {
+    this.set('show', true);
+    this.render(hbs`
+      {{#if this.show}}
+        <div>
+          <div id="my-element" {{css-transition "example" didTransitionIn=this.didTransitionIn didTransitionOut=this.didTransitionOut}}>
+            <p class="content">Çup?</p>
+          </div>
+        </div>
+      {{/if}}
+    `);
+    await waitFor('#my-element.example-enter-active');
+    await waitFor('#my-element:not(.example-enter)');
+    this.set('show', false);
+    assert.dom('#my-element').doesNotExist();
+  });
+
+  test('teardown after removal of sibling element', async function(assert) {
+    this.set('show', true);
+    this.set('showSibling', true);
+    this.render(hbs`
+      {{#if this.show}}
+        <div>
+          <div id="my-element" {{css-transition "example" didTransitionIn=this.didTransitionIn didTransitionOut=this.didTransitionOut}}>
+            <p class="content">Çup?</p>
+          </div>
+          {{#if this.showSibling}}
+            <div data-test-sibling>Sibling element</div>
+          {{/if}}
+        </div>
+      {{/if}}
+    `);
+    await waitFor('#my-element.example-enter-active');
+    await waitFor('#my-element:not(.example-enter)');
+    this.set('showSibling', false);
+    assert.dom('[data-test-sibling]').doesNotExist();
+    this.set('show', false);
+    assert.dom('#my-element').doesNotExist();
+  });
 });


### PR DESCRIPTION
I experienced sporadic test failures when an element is a css-transition modifier is removed soon after it is added. The new tests in this commit illustrate the timing issues that can occur, and add guards to avoid them causing runtime errors.

I find the many guards distasteful, but I don't know a better way to account for these edge cases. Normally I would reach for ember-concurrency, but the fact that some of this code is running asynchronously after teardown *by design* makes e-c not a great fit.