### PR TITLE
add tailwindui instructions to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,25 @@ Animations are completely based on CSS classes.
 
 ## How it works
 
-Utimately you define your animations and transitions with only css like:
+Ultimately you define your animations and transitions with only css like:
 
 ```css
 /* initial state */
-.example-enter, .example-leave-to {
+.example-enter,
+.example-leave-to {
   opacity: 0;
 }
 
 /* final state */
-.example-enter-to, .example-leave {
+.example-enter-to,
+.example-leave {
   opacity: 1;
 }
 
 /* easings */
-.example-enter-active, .example-leave-active {
-  transition: opacity .5s ease-in;
+.example-enter-active,
+.example-leave-active {
+  transition: opacity 0.5s ease-in;
 }
 ```
 
@@ -53,6 +56,32 @@ or by manually specifying classes, perfect for libraries like [Animate.css](http
   <h1>Hello world</h1>
 </div>
 ```
+
+If you are using [TailwindUI](https://tailwindui.com) then you will see transition instructions included in the code, as in this example:
+
+```hbs
+<!--
+  Slide-over panel, show/hide based on slide-over state.
+
+  Entering: "transform transition ease-in-out duration-500 sm:duration-700"
+    From: "translate-x-full"
+    To: "translate-x-0"
+  Leaving: "transform transition ease-in-out duration-500 sm:duration-700"
+    From: "translate-x-0"
+    To: "translate-x-full"
+-->
+```
+
+You should map these instructions to this addon's API in the following way:
+
+| TailwindUI | Addon            |
+| ---------- | ---------------- |
+| Entering   | enterActiveClass |
+| From       | enterClass       |
+| To         | enterToClass     |
+| Leaving    | leaveActiveClass |
+| From       | leaveClass       |
+| To         | leaveToClass     |
 
 Check out the homepage for more detailed documentation: [https://peec.github.io/ember-css-transitions/](https://peec.github.io/ember-css-transitions/)
 
@@ -85,30 +114,29 @@ Note: **IE9** does not support CSS3 transitions / animations. They must live wit
 
 ## Contribute
 
-* `git clone <repository-url>` this repository
-* `cd my-addon`
-* `npm install`
+- `git clone <repository-url>` this repository
+- `cd my-addon`
+- `npm install`
 
 ### Linting
 
-* `npm run lint:hbs`
-* `npm run lint:js`
-* `npm run lint:js -- --fix`
+- `npm run lint:hbs`
+- `npm run lint:js`
+- `npm run lint:js -- --fix`
 
 ### Running tests
 
-* `ember test` – Runs the test suite on the current Ember version
-* `ember test --server` – Runs the test suite in "watch mode"
-* `ember try:each` – Runs the test suite against multiple Ember versions
+- `ember test` – Runs the test suite on the current Ember version
+- `ember test --server` – Runs the test suite in "watch mode"
+- `ember try:each` – Runs the test suite against multiple Ember versions
 
 ### Running the dummy application
 
-* `ember serve`
-* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
+- `ember serve`
+- Visit the dummy application at [http://localhost:4200](http://localhost:4200).
 
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
 
-License
-------------------------------------------------------------------------------
+## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/tests/dummy/app/templates/docs/insert-destroy.md
+++ b/tests/dummy/app/templates/docs/insert-destroy.md
@@ -33,20 +33,21 @@ Here is a diagram taken from the [VueJS docs](https://vuejs.org/v2/guide/transit
 Let's look at one example:
 
 {{#docs-demo as |demo|}}
-  {{#demo.example name="slide-fade.hbs"}}
-    <button class="docs-btn" {{on "click" (fn (mut this.show) (not show))}}>
-      Toggle
-    </button>
+{{#demo.example name="slide-fade.hbs"}}
+<button class="docs-btn" {{on "click" (fn (mut this.show) (not show))}}>
+Toggle
+</button>
 
     {{#if this.show}}
       <div {{css-transition "slide-fade"}}>
         <h1>Hello world</h1>
       </div>
     {{/if}}
-  {{/demo.example}}
 
-  {{demo.snippet "slide-fade.css"}}
-  {{demo.snippet "slide-fade.hbs"}}
+{{/demo.example}}
+
+{{demo.snippet "slide-fade.css"}}
+{{demo.snippet "slide-fade.hbs"}}
 {{/docs-demo}}
 
 ## Custom Transition Classess
@@ -64,10 +65,10 @@ This is perfect for libraries like [Animate.css](https://animate.style/) and [Ta
 Here is an example with TailwindCSS-like styles:
 
 {{#docs-demo as |demo|}}
-  {{#demo.example name="insert-destroy-verbose.hbs"}}
-    <button class="docs-btn" {{on "click" (fn (mut this.show2) (not show2))}}>
-      Toggle
-    </button>
+{{#demo.example name="insert-destroy-verbose.hbs"}}
+<button class="docs-btn" {{on "click" (fn (mut this.show2) (not show2))}}>
+Toggle
+</button>
 
     {{#if this.show2}}
       <div {{css-transition
@@ -80,11 +81,37 @@ Here is an example with TailwindCSS-like styles:
         <h1>Hello world</h1>
       </div>
     {{/if}}
-  {{/demo.example}}
 
-  {{demo.snippet "insert-destroy-verbose.hbs"}}
-  {{demo.snippet "insert-destroy-verbose.css"}}
+{{/demo.example}}
+
+{{demo.snippet "insert-destroy-verbose.hbs"}}
+{{demo.snippet "insert-destroy-verbose.css"}}
 {{/docs-demo}}
 
-
 You're free to customize your element like you normally would. The modifier will only apply and remove the transition classes and nothing else.
+
+If you are using [TailwindUI](https://tailwindui.com) then you will see transition instructions included in the code, as in this example:
+
+```hbs
+<!--
+  Slide-over panel, show/hide based on slide-over state.
+
+  Entering: "transform transition ease-in-out duration-500 sm:duration-700"
+    From: "translate-x-full"
+    To: "translate-x-0"
+  Leaving: "transform transition ease-in-out duration-500 sm:duration-700"
+    From: "translate-x-0"
+    To: "translate-x-full"
+-->
+```
+
+You should map these instructions to this addon's API in the following way:
+
+| TailwindUI | Addon            |
+| ---------- | ---------------- |
+| Entering   | enterActiveClass |
+| From       | enterClass       |
+| To         | enterToClass     |
+| Leaving    | leaveActiveClass |
+| From       | leaveClass       |
+| To         | leaveToClass     |


### PR DESCRIPTION
I've added information about how to map the instructions seen in TailwindUI code to the arguments you pass into the css-transition component.

Possibly not needed in the README as well as the docs? I've put it in both cases just in case.

Thanks 👍🏻